### PR TITLE
feat: Configure Groq and Cerebras providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,12 @@ NOVITA_API_KEY = ""
 # INFINITY
 INFINITY_API_KEY = ""
 
+# Groq
+GROQ_API_KEY = ""
+
+# Cerebras
+CEREBRAS_API_KEY = ""
+
 # Development Configs
 LITELLM_MASTER_KEY = "sk-1234"
 DATABASE_URL = "postgresql://llmproxy:dbpassword9090@db:5432/litellm"

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,12 @@
+model_list:
+  - model_name: groq-llama3
+    litellm_params:
+      model: groq/llama3-8b-8192
+      api_key: os.environ/GROQ_API_KEY
+  - model_name: cerebras-llama3
+    litellm_params:
+      model: cerebras/llama3-70b-instruct
+      api_key: os.environ/CEREBRAS_API_KEY
+
+litellm_settings:
+  set_verbose: True

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "vercel_app.py",
+      "use": "@vercel/python",
+      "config": { "maxLambdaSize": "15mb", "runtime": "python3.9" }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "vercel_app.py"
+    }
+  ]
+}

--- a/vercel_app.py
+++ b/vercel_app.py
@@ -1,0 +1,11 @@
+import litellm
+from litellm.proxy.proxy_server import app
+import os
+
+# Set the config file path
+os.environ["LITELLM_CONFIG_PATH"] = os.path.join(os.getcwd(), "config.yml")
+
+# The 'app' object from litellm.proxy.proxy_server is the FastAPI app.
+# Vercel will automatically detect and serve it.
+# No need to run uvicorn manually.
+litellm.set_verbose=True


### PR DESCRIPTION
This commit updates the `config.yml` to use Groq and Cerebras as the LLM providers, replacing OpenAI and Anthropic.

- The `config.yml` is updated to use `groq/llama3-8b-8192` and `cerebras/llama3-70b-instruct`.
- The `.env.example` file is updated to include the `GROQ_API_KEY` and `CEREBRAS_API_KEY` environment variables.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


