### PR TITLE
fix: Correct Vercel build configuration for Next.js UI

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
       "config": { "maxLambdaSize": "15mb", "runtime": "python3.9" }
     },
     {
-      "src": "ui/litellm-dashboard/next.config.mjs",
+      "src": "ui/litellm-dashboard/package.json",
       "use": "@vercel/next",
       "config": {
         "cwd": "ui/litellm-dashboard"


### PR DESCRIPTION
This commit fixes the Vercel build error by updating the `src` property for the `@vercel/next` builder in the `vercel.json` file. The `src` property now correctly points to the `package.json` file of the Next.js application.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


